### PR TITLE
Quick fix for intermittent File Manager malfunction

### DIFF
--- a/EsPy/Units/PySerial.cs
+++ b/EsPy/Units/PySerial.cs
@@ -379,8 +379,9 @@ namespace EsPy.Units
             List<string> prog = new List<string>();
             prog.Add("import os");
             prog.Add("l=os.listdir()");
+            prog.Add("cur=os.getcwd()+'/'");
             prog.Add("for f in l:");
-            prog.Add(" s=os.stat(f)");
+            prog.Add(" s=os.stat(cur+f)");
             prog.Add(" print('{0},{1},{2}'.format(f, s[0], s[6]))\r\n\b");
             ResultStatus res = this.Exec(prog);
             if (res.Result == ResultStatus.Statuses.Success)


### PR DESCRIPTION
Sometimes File Manager throws an "Index out of range" alert when navigating in ESP filesystem. 
Seems that os.chdir() does not apply to os.stat() search path. Full path is generated and passed instead.
